### PR TITLE
docs: READMEのクローンURLおよびリポジトリ名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 **1. リポジトリのclone**
 
 ```bash
-git clone https://github.com/if-mentor/next_teamdev_template.git
+git clone https://github.com/if-mentor/next_teamdev_24_2.git
 ```
 
 **2. 依存関係のインストール**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "next_teamdev_template",
+  "name": "next_teamdev_24_2",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next_teamdev_template",
+      "name": "next_teamdev_24_2",
       "version": "1.0.0",
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
@@ -58,6 +58,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1311,6 +1312,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
       "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.100.1",
         "@supabase/functions-js": "2.100.1",
@@ -1378,6 +1380,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1446,6 +1449,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1971,6 +1975,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2343,6 +2348,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2973,6 +2979,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3174,6 +3181,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5164,6 +5172,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5283,6 +5292,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5292,6 +5302,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6210,6 +6221,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6577,6 +6589,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next_teamdev_template",
+  "name": "next_teamdev_24_2",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## 概要（何をしたPRか）

環境構築手順における `git clone` URL がテンプレートリポジトリのままになっていたため、本プロジェクトの URL に修正しました。また、プロジェクト名（`package.json`）も合わせて現在のリポジトリ名に統一しました。

## 関連Issue

Closes # なし

## 変更内容

- `README.md`: `git clone` の URL を `next_teamdev_24_2` に修正
- `package.json`: プロジェクト名を `next_teamdev_template` から `next_teamdev_24_2` に変更
- `package-lock.json`: プロジェクト名変更を反映するため `npm install` を実行し更新

## 影響範囲

- [ ] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel
- [x] その他（ドキュメント・設定ファイルのみ）

## 動作確認方法

1.  `README.md` の 16 行目の URL が `https://github.com/if-mentor/next_teamdev_24_2.git` になっていることを確認
2.  `npm install` が正常に完了することを確認

## テストケース

- [ ] ログインができる
- [ ] バリデーションが発火する
- [x] 正常系の確認ができる（npm install が通る）
- [ ] 異常系の確認ができる

## スクリーンショット（UI変更がある場合）

なし（ドキュメント修正のため）

## レビューしてほしい部分や不安な部分

私自身が README 通りに進めた結果、誤ってテンプレート側をクローンしてしまい、push 時にエラーが出るまで気づけなかったという経緯があります。
今後参加するメンバーが同じトラブルで時間を溶かさないよう、この修正をマージいただくと良いかもしれません。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した