### PR TITLE
feat: SelectBoxコンポーネントの実装

### DIFF
--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -1,0 +1,24 @@
+import styles from "./styles.module.css";
+import type { SelectBoxProps } from "./type";
+
+const SelectBox = ({ label, value, placeholder, disabled, ...selectProps }: SelectBoxProps) => {
+  return (
+    <div className={styles.wrapper}>
+      {label && <label className={styles.label}>{label}</label>}
+      <select className={styles.select} disabled={disabled} defaultValue="" {...selectProps}>
+        {placeholder && (
+          <option value="" disabled hidden>
+            {placeholder}
+          </option>
+        )}
+        {value?.map((item) => (
+          <option key={item} value={item}>
+            {item}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default SelectBox;

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -1,17 +1,17 @@
 import styles from "./styles.module.css";
 import type { SelectBoxProps } from "./type";
 
-const SelectBox = ({ label, value, placeholder, disabled, ...selectProps }: SelectBoxProps) => {
+const SelectBox = ({ label, options, placeholder, ...selectProps }: SelectBoxProps) => {
   return (
     <div className={styles.wrapper}>
       {label && <label className={styles.label}>{label}</label>}
-      <select className={styles.select} disabled={disabled} defaultValue="" {...selectProps}>
+      <select className={styles.select} defaultValue="" {...selectProps}>
         {placeholder && (
-          <option value="" disabled hidden>
+          <option value="" disabled>
             {placeholder}
           </option>
         )}
-        {value?.map((item) => (
+        {options?.map((item) => (
           <option key={item} value={item}>
             {item}
           </option>

--- a/src/components/SelectBox/styles.module.css
+++ b/src/components/SelectBox/styles.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 0px; /* Label 17px + Select 40px = 57px となるため隙間ゼロ */
+  width: 240px;
+}
+
+.label {
+  display: flex;
+  align-items: center; /* 行の高さ調整 */
+  width: 100%;
+  height: 17px; /* Figma指定 */
+  font-family: "Geist", sans-serif;
+  font-weight: 400;
+  font-size: 12px;
+  color: #1e1e1e; /* 黒に近いグレー */
+}
+
+.select {
+  box-sizing: border-box; /* paddingを含めて高さ40pxにするため */
+  width: 100%;
+  height: 40px; /* Figma指定 */
+  padding: 8px 8px 8px 12px; /* 上・右・下・左 */
+
+  font-family: "Geist", "Inter", sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  color: #1e1e1e;
+
+  background-color: #ffffff;
+  border: 1px solid #d8d8d8; /* Figma指定のボーダー色 */
+  border-radius: 8px; /* Figma指定の角丸 */
+  outline: none;
+  cursor: pointer;
+}
+
+/* 使う側（ブラウザ）の挙動としてのフォーカス・非活性はFigmaに無いので標準的なものを付与 */
+.select:focus {
+  border-color: #1e1e1e; /* フォーカス時は少し濃く */
+}
+
+.select:disabled {
+  background-color: #f5f5f5;
+  color: #999999;
+  cursor: not-allowed;
+}

--- a/src/components/SelectBox/type.ts
+++ b/src/components/SelectBox/type.ts
@@ -1,6 +1,5 @@
-export type SelectBoxProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value"> & {
+export type SelectBoxProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
   label?: string;
-  value: string[];
+  options: string[];
   placeholder?: string;
-  disabled?: boolean;
 };

--- a/src/components/SelectBox/type.ts
+++ b/src/components/SelectBox/type.ts
@@ -1,0 +1,6 @@
+export type SelectBoxProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "value"> & {
+  label?: string;
+  value: string[];
+  placeholder?: string;
+  disabled?: boolean;
+};


### PR DESCRIPTION
@takanorishinagawa 

## 概要（何をしたPRか）

投稿画面や編集画面で利用するための `SelectBox` コンポーネントを新規実装しました。
Issueでの質問回答を受け、与えられた文字列のリスト（`value`）をシンプルにレンダリングする仕様にしています。

## 関連Issue

Closes #13

## 変更内容

- `src/components/SelectBox/` 配下のファイル新規作成
  - `index.tsx`: コンポーネント本体の実装（非制御コンポーネントベース）
  - `type.ts`: `SelectBoxProps` の型定義追加（`value: string[]` で選択肢を受け取る対応）
  - `styles.module.css`: Figmaの設計データに基づいたレイアウト（240px固定、gap、padding等）の適用

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

ローカル環境にて、`src/app/page.tsx` を一時的に以下のコードに書き換えることで動作確認が可能です。

動作確認用のコード
```tsx
import styles from "./styles.module.css";
import SelectBox from "@/components/SelectBox";

export default function Home() {
  return (
    <div>  
      <SelectBox
        label="カテゴリ"
        value={['apple', 'banana', 'orange']}
        placeholder="カテゴリ選択"
        disabled={false} // trueで非活性
      />
    </div>
  );
}
```
</details>

1. 上記のコードを適用して画面を表示
2. 画面にセレクトボックスが表示され、初期状態としてプレースホルダーが選択されていることを確認
3. ドロップダウンを開いた際に、渡した値が選択肢として展開されることを確認
4. `disabled={true}` に書き換えた際、ネイティブのselectの挙動として非活性（グレーアウト）になることを確認

## テストケース

- [x] 指定した `label` が正しく表示されること
- [x] 指定した `placeholder` が初期表示されるが、選択リストには有効な操作肢として出ない（disabled hidden）こと
- [x] `value` で渡した配列の文字列が、一つ一つの `<option>` として表示されること
- [x] `disabled={true}` を渡した際に全体が非活性になること

## スクリーンショット（UI変更がある場合）

<img width="246" height="67" alt="image" src="https://github.com/user-attachments/assets/0241fe3e-55f2-435a-a678-cf9f6e44dae8" />
<img width="251" height="71" alt="image" src="https://github.com/user-attachments/assets/1027c6f9-82b9-49d5-a800-cfdaa7ed0e0b" />
<img width="253" height="69" alt="image" src="https://github.com/user-attachments/assets/258423ff-44cd-4c80-b288-af18212636dd" />

## レビューしてほしい部分や不安な部分

- ご指摘いただいたフィードバック内容（「現在選択中の値と選択肢リストを分けず、`value`のみで実装する」）を反映させていただきました。こちらの意図とすり合っているかご確認ください。
- ドロップダウンの矢印部分はブラウザ標準のものに戻しています。デザイン上で考慮すべき点があれば対応いたしますので教えてください。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
