### PR TITLE
feat: ImageUploaderPreviewコンポーネントを追加

### DIFF
--- a/src/components/ImageUploaderPreview/index.tsx
+++ b/src/components/ImageUploaderPreview/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import styles from "./styles.module.css";
 import type { ImageUploaderPreviewProps } from "./type";
@@ -19,18 +19,19 @@ const ImageUploaderPreview = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const file = value !== undefined ? value : imageFile;
+  const [localUrl, setLocalUrl] = useState<string | null>(null);
 
-  // File → blob URL に変換（useMemo で同期的に計算）
-  const localUrl = useMemo(() => {
-    if (!file) return null;
-    return URL.createObjectURL(file);
-  }, [file]);
-
-  // blob URL のメモリ解放（localUrl が変わった時 or アンマウント時）
   useEffect(() => {
-    if (!localUrl) return;
-    return () => URL.revokeObjectURL(localUrl);
-  }, [localUrl]);
+    if (!file) {
+      queueMicrotask(() => setLocalUrl(null));
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    queueMicrotask(() => setLocalUrl(url));
+
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
 
   const displayUrl = localUrl || (!file && previewUrl ? previewUrl : null);
 

--- a/src/components/ImageUploaderPreview/index.tsx
+++ b/src/components/ImageUploaderPreview/index.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import Image from "next/image";
+import styles from "./styles.module.css";
+import type { ImageUploaderPreviewProps } from "./type";
+
+const ImageUploaderPreview = ({
+  imageFile,
+  value,
+  previewUrl,
+  accept = "image/png, image/jpeg, image/jpg",
+  disabled = false,
+  error,
+  onChange,
+}: ImageUploaderPreviewProps) => {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [localImageError, setLocalImageError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const file = value !== undefined ? value : imageFile;
+
+  // File → blob URL に変換（useMemo で同期的に計算）
+  const localUrl = useMemo(() => {
+    if (!file) return null;
+    return URL.createObjectURL(file);
+  }, [file]);
+
+  // blob URL のメモリ解放（localUrl が変わった時 or アンマウント時）
+  useEffect(() => {
+    if (!localUrl) return;
+    return () => URL.revokeObjectURL(localUrl);
+  }, [localUrl]);
+
+  const displayUrl = localUrl || (!file && previewUrl ? previewUrl : null);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled) setIsDragActive(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled) setIsDragActive(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragActive(false);
+    if (disabled) return;
+
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      handleFileChange(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleFileChange = (selectedFile: File) => {
+    setLocalImageError(null);
+    if (accept) {
+      const acceptedTypes = accept.split(",").map((t) => t.trim());
+      const isValid = acceptedTypes.some((type) => {
+        if (type.endsWith("/*")) {
+          return selectedFile.type.startsWith(type.replace("/*", ""));
+        }
+        return selectedFile.type === type;
+      });
+
+      if (!isValid && acceptedTypes.length > 0) {
+        return;
+      }
+    }
+    onChange?.(selectedFile);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      handleFileChange(e.target.files[0]);
+    }
+    e.target.value = "";
+  };
+
+  const handleClick = () => {
+    if (!disabled) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  return (
+    <>
+      <div
+        className={`${styles.dropzone} ${isDragActive ? styles.dropzoneActive : ""} ${
+          error ? styles.dropzoneError : ""
+        } ${disabled ? styles.disabled : ""}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={handleClick}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={accept}
+          className={styles.input}
+          onChange={handleInputChange}
+          disabled={disabled}
+        />
+        {displayUrl && !localImageError ? (
+          <Image
+            src={displayUrl}
+            alt="Preview"
+            fill
+            unoptimized
+            className={styles.previewImage}
+            onError={() => {
+              setLocalImageError("画像ファイルとして読み込めませんでした。");
+              onChange?.(null);
+            }}
+          />
+        ) : (
+          <div className={styles.placeholder}>
+            <button type="button" className={styles.uploadButton} disabled={disabled}>
+              画像アップロード
+            </button>
+          </div>
+        )}
+      </div>
+      {(error || localImageError) && <p className={styles.errorMessage}>{error || localImageError}</p>}
+    </>
+  );
+};
+
+export default ImageUploaderPreview;

--- a/src/components/ImageUploaderPreview/styles.module.css
+++ b/src/components/ImageUploaderPreview/styles.module.css
@@ -1,0 +1,83 @@
+.dropzone {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 200px;
+  background-color: transparent;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  overflow: hidden;
+  border: 2px dashed #000000;
+  transition: all 0.2s ease-in-out;
+}
+
+.dropzone:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.dropzoneActive {
+  border-color: #18a0fb;
+  background-color: rgba(24, 160, 251, 0.1);
+}
+
+.dropzoneError {
+  border-color: red;
+}
+
+.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.disabled:hover {
+  background-color: #e3e3e3cf;
+}
+
+.input {
+  display: none;
+}
+
+.previewImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.uploadButton {
+  width: 120px;
+  height: 40px;
+  background: #18a0fb;
+  border-radius: 6px;
+  font-family: inherit;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  pointer-events: none;
+}
+
+.errorMessage {
+  margin-top: 4px;
+  font-size: 12px;
+  color: red;
+}

--- a/src/components/ImageUploaderPreview/type.ts
+++ b/src/components/ImageUploaderPreview/type.ts
@@ -1,0 +1,9 @@
+export type ImageUploaderPreviewProps = {
+  imageFile?: File | null;
+  value?: File | null;
+  previewUrl?: string;
+  accept?: string;
+  disabled?: boolean;
+  error?: string;
+  onChange?: (file: File | null) => void;
+};


### PR DESCRIPTION
## 概要（何をしたPRか）

記事投稿・編集画面で使用する、画像アップロードおよびプレビュー表示を行う `ImageUploaderPreview` コンポーネントを新規作成しました。

## 関連Issue

Closes #17

## 変更内容

新規追加ファイル：

```text
src/components/ImageUploaderPreview/
├── index.tsx          # コンポーネント本体
├── styles.module.css  # スタイル定義
└── type.ts            # Propsの型定義
```

| 名前 | 種別 | 説明 |
|---|---|---|
| `ImageUploaderPreview` | export default | 画像アップロード（クリック・D&D）およびプレビュー表示を行うコンポーネント |
| `ImageUploaderPreviewProps` | named export | ImageUploaderPreview の Props 型定義 |


## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. 任意のページ（`src/app/page.tsx` など）を以下のコードで上書きし、ローカルサーバーを起動する
    ```tsx
    "use client";

    import { useState } from "react";
    import ImageUploaderPreview from "@/components/ImageUploaderPreview";

    export default function Home() {
      const [file, setFile] = useState<File | null>(null);

      return (
        <div>
          {/* 動作確認用ラッパー：実際のページ側でコンテナのサイズを指定するイメージ */}
          <div style={{ width: "50%", height: "300px", margin: "0 auto" }}>
            <ImageUploaderPreview
              value={file}
              onChange={setFile}
            />
          </div>
        </div>
      );
    }
    ```
2. レンダリングされた枠内をクリック、または画像をドラッグ＆ドロップしてローカルの画像を選択する
3. 選択した画像がプレビューとしてコンテナいっぱいに表示されることを確認する
4. （確認が終わったら呼び出し元のコードを元に戻す）

## テストケース

- [x] クリックでファイル選択ダイアログが開き、画像が選択できる
- [x] ドラッグ＆ドロップで画像が選択できる
- [x] 選択した画像がプレビュー表示される
- [x] PNG、JPEG以外のファイル（テキストファイルなど）を選択した場合、無視される（バリデーション発火）
- [x] 拡張子を偽装した非画像ファイル等を読み込ませた場合、「画像ファイルとして読み込めませんでした。」とエラーになり状態がリセットされる
- [x] `disabled={true}` を渡した際、見た目がグレーアウトしクリック・D&D操作ができなくなる

## スクリーンショット（UI変更がある場合）

<!-- コンポーネント単体の表示キャプチャ（通常時、プレビュー時、エラー時など）を貼る -->

## レビューしてほしい部分や不安な部分

- **Propsの命名仕様との差異**: 仕様書の `imageFile: File` に加え、一般的なフォームコンポーネントとしての使い勝手を考慮し、`value` および `onChange` イベントを独自に追加しています。設計方針として問題ないかご確認をお願いします。（使い方は `<ImageUploaderPreview value={file} onChange={setFile} />` を想定しています）
- **コンポーネントの高さ制御**: `ImageUploaderPreview` 自身は高さを定義せず、親要素のコンテナの高さいっぱいにプレビューが収まる（`object-fit: cover`）作りにしています。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）