### PR TITLE
feat: implement signup page UI

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Header from "@/components/Header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} 
   ${geistMono.variable}`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import Button from "@/components/Button";
+import TextBox from "@/components/TextBox";
+import Header from "@/components/Header";
+import styles from "./styles.module.css";
+
+export default function SignUpPage() {
+  return (
+    <div className={styles.container}>
+      <Header />
+      <div className={styles.card}>
+        <h1 className={styles.title}>新規登録</h1>
+        <form className={styles.form}>
+          <div className={styles.inputGroup}>
+            <TextBox label="名前" placeholder="名前を入力" name="name" required />
+          </div>
+
+          <div className={styles.inputGroup}>
+            <TextBox label="メールアドレス" type="email" placeholder="メールアドレスを入力" name="email" required />
+          </div>
+
+          <div className={styles.inputGroup}>
+            <TextBox label="パスワード" type="password" placeholder="パスワードを入力" name="password" required />
+          </div>
+
+          <div className={styles.buttonContainer}>
+            <Button variant="success" size="lg" type="submit">
+              登録する
+            </Button>
+          </div>
+        </form>
+        <div className={styles.footerLink}>
+          すでにアカウントをお持ちの方は
+          <Link href="/login" className={styles.link}>
+            ログイン
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/styles.module.css
+++ b/src/app/signup/styles.module.css
@@ -1,0 +1,72 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 72px); /* ヘッダー高さ72pxを引く */
+  background-color: #ffffff;
+}
+
+.card {
+  width: 792px;
+  background-color: #ffffff;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* Figmaのカード高さ767pxを再現するため上下余白を広げる */
+  padding: 106px 0;
+}
+
+.title {
+  font-family: "Geist", sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 42px;
+  color: #000000;
+  margin-bottom: 32px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.inputGroup {
+  margin: 24px 0;
+  width: 480px;
+  display: flex;
+  flex-direction: column;
+}
+
+.inputGroup label {
+  line-height: 24px;
+}
+
+.inputGroup:last-of-type {
+  margin-bottom: 0;
+}
+
+.buttonContainer {
+  margin-top: 32px;
+  margin-bottom: 0;
+}
+
+.footerLink {
+  width: 480px;
+  display: flex;
+  justify-content: flex-end;
+  font-family: "Geist", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  color: #000000;
+  margin-top: 8px;
+}
+
+.link {
+  color: #18a0fb;
+  text-decoration: none;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）

ワイヤーフレームに基づき、サインアップ画面（UI部分）を新規実装しました。
既存の `TextBox` コンポーネントおよび `Button` コンポーネントを活用し、Figmaの設計データに合わせたレイアウトとスタイリングを行っています。

※本PRはフロントエンドのUI作成のみをスコープとしており、Supabaseへの登録などバックエンドの機能面は含んでいません。

## 関連Issue

Closes #20

## 変更内容

- `src/app/signup/` 配下のファイル新規作成
  - `page.tsx`: サインアップ画面のUI構造の実装。また、後続の機能開発に備え各項目に `required` を、ボタンに `type="submit"` を付与しました。
  - `styles.module.css`: Figmaの設計データに基づいたレイアウト（余白・要素間の間隔など）の適用。

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

ローカル環境にて開発サーバーを起動し、ブラウザで `/signup` にアクセスしてください。

1. サインアップ画面が表示され、画面中央に白背景のフォーム（カード状）が配置されていることを確認
2. 「名前」「メールアドレス」「パスワード」の各入力枠がワイヤーフレーム通りに表示されていることを確認
3. 「登録する」ボタン、および下部にログイン画面へのリンクが表示されていることを確認

## テストケース

- [x] 指定した `TextBox`（名前・メール・パスワード）と `Button` が正しく表示されること
- [x] フォームのレイアウト・余白がワイヤーフレームの指定から大きく乖離していないこと
- [x] ログイン画面へのテキストリンクが表示されており、正しいパス（`/login`）が指定されていること
- [x] 空の状態で送信（登録ボタン押下）しようとした際に、必須チェック（`required`属性）が機能すること

## スクリーンショット（UI変更がある場合）

<img width="1442" height="1001" alt="image" src="https://github.com/user-attachments/assets/ab3e8882-97f1-42e9-a519-8b39dff13996" />

## レビューしてほしい部分や不安な部分

- `TextBox` コンポーネントの既存のスタイル（グレー背景・枠線なし）がFigmaの設計（白背景・枠線あり）と異なっていましたが、すでに作成済みのコンポーネントであったためそのまま使用しました。Figmaの設計に合わせる必要がないか、ご確認をお願いします。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
