### PR TITLE
ホーム画面　作成

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/Button";
 import PostCard from "@/components/PostCard";
 
 export default function Home() {
-  // task24 ホーム画面作成時のダミーデータ
+  // task24 ホーム画面作成時のダミーデータ sampleCardはバックエンド作成後に削除予定
   const sampleCard = {
     title: "title",
     author: "author",
@@ -16,12 +16,10 @@ export default function Home() {
     <div className={styles.container}>
       <div className={styles.searchWrapper}>
         <TextBox placeholder="検索したい記事を入力してください" />
-        <Button variant="secondary" size="md">
-          検索
-        </Button>
+        <Button variant="secondary">検索</Button>
       </div>
       <div className={styles.cardWrapper}>
-        {/*task24 ホーム画面作成時のダミーデータ*/}
+        {/*task24 ホーム画面作成時のダミーデータ　バックエンド作成時に修正予定*/}
         {Array.from({ length: 7 }).map((_, i) => (
           <PostCard
             key={i}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,40 @@
 import styles from "./styles.module.css";
+import TextBox from "@/components/TextBox";
+import Button from "@/components/Button";
+import PostCard from "@/components/PostCard";
 
 export default function Home() {
+  // task24 ホーム画面作成時のダミーデータ
+  const sampleCard = {
+    title: "title",
+    author: "author",
+    category: "category",
+    content: "content",
+    createdAt: "2026-04-18T09:00:00+09:00",
+  };
   return (
-    <div>
-      <h1 className={styles.title}>Hello Teamdev!!</h1>
+    <div className={styles.container}>
+      <div className={styles.searchWrapper}>
+        <TextBox placeholder="検索したい記事を入力してください" />
+        <Button variant="secondary" size="md">
+          検索
+        </Button>
+      </div>
+      <div className={styles.cardWrapper}>
+        {/*task24 ホーム画面作成時のダミーデータ*/}
+        {Array.from({ length: 7 }).map((_, i) => (
+          <PostCard
+            key={i}
+            title={sampleCard.title}
+            author={sampleCard.author}
+            category={sampleCard.category}
+            thumbnailUrl=""
+            content={sampleCard.content}
+            createdAt={sampleCard.createdAt}
+          />
+        ))}
+        {/*ダミーデータ終了*/}
+      </div>
     </div>
   );
 }

--- a/src/app/styles.module.css
+++ b/src/app/styles.module.css
@@ -1,6 +1,22 @@
-.title {
+.container {
   height: 100vh;
   display: flex;
-  justify-content: center;
   align-items: center;
+  flex-direction: column;
+  margin-top: 72px;
+}
+.searchWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+  margin-top: 36px;
+}
+.cardWrapper {
+  margin: 52px 64px 64px 0;
+  gap: 60px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
 }


### PR DESCRIPTION
## 概要（何をしたPRか）

ホーム画面でカード一覧を確認できるように、ホーム画面の`src/app/page.tsx`に検索欄と1行4列のcardコンポーネントを表示できるように実装した。

## 関連Issue

Closes #24 

<!-- 例: Closes #1 と書くと、マージ時に対応するIssueが自動で閉じます -->

## 変更内容

-`src/app/page.tsx`と`src/app/styles.module.css`を編集し、既存のhタグの要素を削除した
- `page.tsx`に、TextBoxとButtonコンポーネントを横並びで配置した
-  `page.tsx`に、Cardコンポーネントのダミーデータを用意し、横幅1440pxの画面で1行につき4列表示させた


## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. 開発環境でサーバーを立ち上げ、localhost:3000を開く
2. 開発ツールで画面の横幅を1440pxに調整する

## テストケース


- [x] 正常系の確認ができる
  - 画面サイズが1440pxのときに、cardが水平方向に4つ表示される
  - ButtonコンポーネントがTextBoxコンポーネントの、垂直方向の真ん中の位置にある

## スクリーンショット（UI変更がある場合）

[![Image from Gyazo](https://i.gyazo.com/aaf561f1f581e11c77d4922d08805cf7.png)](https://gyazo.com/aaf561f1f581e11c77d4922d08805cf7)

## レビューしてほしい部分や不安な部分

- ホーム画面のため、`app/page.tsx`のHomeを編集し、既存のh1タグを消している
- ダミーデータを書いたままpushしている

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）
