### PR TITLE
feat: implement login page UI (#23)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import Button from "@/components/Button";
+import TextBox from "@/components/TextBox";
+import styles from "./styles.module.css";
+
+export default function LoginPage() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>ログイン</h1>
+        <form className={styles.form}>
+          <div className={styles.inputGroup}>
+            <TextBox label="メールアドレス" type="email" placeholder="メールアドレスを入力" name="email" required />
+          </div>
+          <div className={styles.inputGroup}>
+            <TextBox label="パスワード" type="password" placeholder="パスワードを入力" name="password" required />
+          </div>
+          <div className={styles.buttonContainer}>
+            <Button variant="success" size="lg" type="submit">
+              ログイン
+            </Button>
+          </div>
+        </form>
+        <div className={styles.footerLink}>
+          アカウントをお持ちでない方は
+          <Link href="/signup" className={styles.link}>
+            新規登録
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/login/styles.module.css
+++ b/src/app/login/styles.module.css
@@ -1,0 +1,72 @@
+.container {
+  display: flex;
+  justify-content: center;
+  padding-top: 180px;
+  min-height: 100vh;
+  background-color: #ffffff;
+}
+
+.card {
+  width: 792px;
+  height: 442px;
+  background-color: #ffffff;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
+  font-family: "Geist", sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 42px;
+  color: #000000;
+  margin-bottom: 32px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.inputGroup {
+  margin-bottom: 48px;
+  width: 480px;
+  display: flex;
+  flex-direction: column;
+}
+
+.inputGroup label {
+  line-height: 24px;
+}
+
+.inputGroup:last-of-type {
+  margin-bottom: 0;
+}
+
+.buttonContainer {
+  margin-top: 32px;
+  margin-bottom: 0;
+}
+
+.footerLink {
+  width: 480px;
+  display: flex;
+  justify-content: flex-end;
+  font-family: "Geist", sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  color: #000000;
+  margin-top: 8px;
+}
+
+.link {
+  color: #18a0fb;
+  text-decoration: none;
+}


### PR DESCRIPTION
## 概要（何をしたPRか）

Figmaのワイヤーフレームをもとに、ログイン画面（`/login`）のUIを実装しました。  
メールアドレス・パスワード入力欄、ログインボタン、新規登録への導線を追加しています。

## 関連Issue

Closes #23

## 変更内容

- `src/app/login/page.tsx` を新規作成し、ログイン画面コンポーネントを実装
- `src/app/login/styles.module.css` を新規作成し、レイアウト・余白・文字サイズ・リンクなどのスタイルを実装
- 入力欄は既存の `TextBox`、ボタンは既存の `Button` を利用してUIを構成
- 「アカウントをお持ちでない方は新規登録」のリンクを `/signup` へ接続

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `pnpm dev` を実行
2. `http://localhost:3000/login` にアクセス
3. ログイン画面が表示されることを確認
4. 「新規登録」リンク押下で `/signup` に遷移することを確認

## テストケース

- [ ] ログインができる（※認証処理は未実装のため今回対象外）
- [x] バリデーションが発火する（required属性による入力必須チェック）
- [x] 正常系の確認ができる（画面表示・入力・リンク遷移）
- [ ] 異常系の確認ができる（※API連携未実装のため今回対象外）

## スクリーンショット（UI変更がある場合）

<img width="1447" height="1009" alt="image" src="https://github.com/user-attachments/assets/b651ac13-4809-4db2-91f0-b29782300ec3" />

## レビューしてほしい部分や不安な部分

- Figmaに対する余白・サイズ感（特にフォーム幅、上下マージン）の再現度

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）
