### PR TITLE
refactor: remove Header component from SignUpPage

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,13 +1,11 @@
 import Link from "next/link";
 import Button from "@/components/Button";
 import TextBox from "@/components/TextBox";
-import Header from "@/components/Header";
 import styles from "./styles.module.css";
 
 export default function SignUpPage() {
   return (
     <div className={styles.container}>
-      <Header />
       <div className={styles.card}>
         <h1 className={styles.title}>新規登録</h1>
         <form className={styles.form}>


### PR DESCRIPTION
## 概要（何をしたPRか）

サインアップ画面に誤って残っていた `Header` コンポーネントを削除しました。  
共通ヘッダーは `layout.tsx` 側のみで表示される構成に統一しています。

## 関連Issue

Closes #28

## 変更内容

- `src/app/signup/page.tsx` から `Header` の import を削除
- `src/app/signup/page.tsx` から `<Header />` の描画を削除

## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `pnpm dev` でアプリを起動する
2. `/signup` にアクセスし、ヘッダーが1つだけ表示されることを確認する（重複表示がないこと）

## テストケース

- [ ] ログインができる
- [ ] バリデーションが発火する
- [x] 正常系の確認ができる
- [ ] 異常系の確認ができる
- [x] `/signup` でヘッダー重複がないことを確認できる

## スクリーンショット（UI変更がある場合）

なし（重複がなくなっただけで、見た目には変化なしです）

## レビューしてほしい部分や不安な部分

- `signup` ページ内で `Header` 削除以外の差分が入っていないか