### PR TITLE
feat: 記事詳細ページ 作成 #27

### DIFF
--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,7 +1,6 @@
 import BlogCard from "@/components/BlogCard";
 import Button from "@/components/Button";
 import CommentCard from "@/components/CommentCard";
-import Link from "next/link";
 import styles from "./styles.module.css";
 
 /*
@@ -20,7 +19,8 @@ const MOCK_ARTICLE = {
   author: "Author",
   category: "Category",
   thumbnailUrl: "/sample1.jpg",
-  content: "ここに記事本文が入ります。ダミーテキストです。複数行の内容を想定したプレースホルダとして表示しています。",
+  content:
+    "ここに記事本文が入ります。ダミーテキストです。複数行の内容を想定したプレースホルダとして表示しています。ここに記事本文が入ります。ダミーテキストです。複数行の内容を想定したプレースホルダとして表示しています。",
   createdAt: new Date(Date.now() - 60 * 1000),
 };
 
@@ -42,6 +42,7 @@ const MOCK_COMMENTS = [
 
 export default async function ArticleDetailPage({ params }: ArticleDetailPageProps) {
   const { id } = await params;
+  void id; // バックエンド実装後に記事取得・編集URLで使用予定
 
   return (
     <main className={styles.page}>
@@ -56,10 +57,6 @@ export default async function ArticleDetailPage({ params }: ArticleDetailPagePro
               content={MOCK_ARTICLE.content}
               createdAt={MOCK_ARTICLE.createdAt}
             />
-            {/* Issue #16（BlogCard）でカード内に移すまで暫定。移設後はこの Link を削除 */}
-            <Link href={`/articles/${id}/edit`} className={styles.cardEditLink}>
-              編集
-            </Link>
           </div>
           <section className={styles.comments} aria-labelledby="comments-heading">
             <h2 id="comments-heading" className={styles.commentsTitle}>

--- a/src/app/articles/[id]/page.tsx
+++ b/src/app/articles/[id]/page.tsx
@@ -1,0 +1,91 @@
+import BlogCard from "@/components/BlogCard";
+import Button from "@/components/Button";
+import CommentCard from "@/components/CommentCard";
+import Link from "next/link";
+import styles from "./styles.module.css";
+
+/*
+ * [FE] 記事詳細 — UI 先行。以下はバックエンド/API 連携後に削除または置き換え予定（GitHub Projects の [BE] と対応）。
+ * - MOCK_* … [BE] 記事詳細取得 などで DB から取得したデータに差し替え
+ * - コメント入力 / Button … コメント投稿 API または Server Action 接続時に実装差し替え（複数行が必要なら textarea へ）
+ * - 編集リンク … [BE] 認証制御・[BE] 記事更新 と画面 #26 実装時に URL・表示条件を確定
+ */
+type ArticleDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/** UI 確認用モック。[BE] 記事詳細取得 完了後に削除し、取得結果を表示する */
+const MOCK_ARTICLE = {
+  title: "Blog Title",
+  author: "Author",
+  category: "Category",
+  thumbnailUrl: "/sample1.jpg",
+  content: "ここに記事本文が入ります。ダミーテキストです。複数行の内容を想定したプレースホルダとして表示しています。",
+  createdAt: new Date(Date.now() - 60 * 1000),
+};
+
+/** UI 確認用モック。コメント一覧 API（または記事詳細に含まれる場合はそのフィールド）接続後に削除 */
+const MOCK_COMMENTS = [
+  {
+    id: "1",
+    userName: "ユーザー名",
+    content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    createdAt: new Date(Date.now() - 60 * 60 * 1000),
+  },
+  {
+    id: "2",
+    userName: "ユーザー名",
+    content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+  },
+];
+
+export default async function ArticleDetailPage({ params }: ArticleDetailPageProps) {
+  const { id } = await params;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.inner}>
+        <div className={styles.stack}>
+          <div className={styles.blogCardShell}>
+            <BlogCard
+              title={MOCK_ARTICLE.title}
+              author={MOCK_ARTICLE.author}
+              category={MOCK_ARTICLE.category}
+              thumbnailUrl={MOCK_ARTICLE.thumbnailUrl}
+              content={MOCK_ARTICLE.content}
+              createdAt={MOCK_ARTICLE.createdAt}
+            />
+            {/* Issue #16（BlogCard）でカード内に移すまで暫定。移設後はこの Link を削除 */}
+            <Link href={`/articles/${id}/edit`} className={styles.cardEditLink}>
+              編集
+            </Link>
+          </div>
+          <section className={styles.comments} aria-labelledby="comments-heading">
+            <h2 id="comments-heading" className={styles.commentsTitle}>
+              {MOCK_COMMENTS.length}件のコメント
+            </h2>
+            <input
+              id="article-comment"
+              className={styles.commentField}
+              type="text"
+              name="comment"
+              placeholder="コメントを入力"
+              aria-label="コメントを入力"
+            />
+            <div className={styles.commentSubmitRow}>
+              <Button variant="success">コメント</Button>
+            </div>
+            <ul className={styles.commentList}>
+              {MOCK_COMMENTS.map((comment) => (
+                <li key={comment.id}>
+                  <CommentCard userName={comment.userName} content={comment.content} createdAt={comment.createdAt} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -77,7 +77,8 @@
 }
 
 .commentField::placeholder {
-  color: rgba(0, 0, 0, 0.4);
+  /* Figma: #000000 / 50% */
+  color: rgba(0, 0, 0, 0.5);
 }
 
 .commentSubmitRow {

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -19,36 +19,9 @@
   gap: 16px;
 }
 
-/* BlogCard の props を増やさず、詳細ページだけで編集導線を重ねる */
 .blogCardShell {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
-  width: 720px;
-  max-width: 100%;
-}
-
-.blogCardShell > :first-child {
-  grid-area: 1 / 1;
-}
-
-.cardEditLink {
-  grid-area: 1 / 1;
-  align-self: end;
-  justify-self: end;
-  width: 120px;
-  height: 40px;
-  margin-right: 40px;
-  margin-bottom: 24px;
-  border-radius: 6px;
-  background-color: #18a0fb;
-  color: #ffffff;
-  font-size: 15px;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1;
+  width: 100%;
+  max-width: 720px;
 }
 
 .comments {
@@ -77,7 +50,6 @@
 }
 
 .commentField::placeholder {
-  /* Figma: #000000 / 50% */
   color: rgba(0, 0, 0, 0.5);
 }
 

--- a/src/app/articles/[id]/styles.module.css
+++ b/src/app/articles/[id]/styles.module.css
@@ -1,0 +1,96 @@
+.page {
+  margin-top: 72px;
+  padding-top: 64px;
+  padding-bottom: 54px;
+  background-color: #ffffff;
+  min-height: calc(100vh - 72px);
+}
+
+.inner {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 36px;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+/* BlogCard の props を増やさず、詳細ページだけで編集導線を重ねる */
+.blogCardShell {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  width: 720px;
+  max-width: 100%;
+}
+
+.blogCardShell > :first-child {
+  grid-area: 1 / 1;
+}
+
+.cardEditLink {
+  grid-area: 1 / 1;
+  align-self: end;
+  justify-self: end;
+  width: 120px;
+  height: 40px;
+  margin-right: 40px;
+  margin-bottom: 24px;
+  border-radius: 6px;
+  background-color: #18a0fb;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.comments {
+  width: 100%;
+  max-width: 720px;
+}
+
+.commentsTitle {
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 30px;
+  letter-spacing: -0.015em;
+  color: #000000;
+  margin-bottom: 16px;
+}
+
+.commentField {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d9e0;
+  border-radius: 5px;
+  font-size: 12px;
+  line-height: 24px;
+  letter-spacing: -0.015em;
+  background-color: #ffffff;
+}
+
+.commentField::placeholder {
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.commentSubmitRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.commentList {
+  list-style: none;
+  margin: 32px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -1,5 +1,6 @@
 import { formatRelativeTime } from "@/utils/formatRelativeTime";
 import Image from "next/image";
+import Link from "next/link";
 import styles from "./styles.module.css";
 import type { BlogCardProps } from "./type";
 
@@ -26,6 +27,10 @@ const BlogCard = ({ title, author, avatarUrl, category, thumbnailUrl, content, c
         <time dateTime={new Date(createdAt).toISOString()} className={styles.createdAt}>
           {formatRelativeTime(createdAt, "en")}
         </time>
+        {/* バックエンド実装後、href={`/articles/${id}/edit`} に差し替え */}
+        <Link href="#" className={styles.editButton}>
+          編集
+        </Link>
       </div>
     </article>
   );

--- a/src/components/BlogCard/styles.module.css
+++ b/src/components/BlogCard/styles.module.css
@@ -1,11 +1,19 @@
 .card {
-  width: 720px;
-  min-height: 640px;
+  width: 100%;
+  max-width: 720px;
   border-radius: 32px;
   border: 1px solid #000000;
-  padding: 32px 40px 104px;
+  padding: 32px 40px;
   background-color: #ffffff;
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1440px) {
+  .card {
+    min-height: 640px;
+  }
 }
 
 .header {
@@ -38,7 +46,7 @@
 
 .thumbnail {
   width: 100%;
-  height: 320px;
+  height: auto;
   object-fit: cover;
 }
 
@@ -55,21 +63,17 @@
   margin-top: 16px;
 }
 
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 24px;
+}
+
 .createdAt {
   font-size: 12px;
   color: rgba(0, 0, 0, 0.5);
-  margin-top: 8px;
-}
-
-/* ✅ footerで一緒に並べる */
-.footer {
-  display: flex;
-  justify-content: space-between; /* 左右に分ける */
-  align-items: center;
-  position: absolute;
-  bottom: 24px;
-  left: 40px; /* createdAtの左位置 */
-  right: 40px;
 }
 
 .editButton {
@@ -83,4 +87,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
 }

--- a/src/components/CommentCard/styles.module.css
+++ b/src/components/CommentCard/styles.module.css
@@ -1,5 +1,6 @@
 .card {
-  width: 720px;
+  width: 100%;
+  max-width: 720px;
   min-height: 96px;
   background-color: #f0f0f0;
   border-radius: 5px;


### PR DESCRIPTION
## 概要（何をしたPRか）

記事詳細ページ（`/articles/[id]`）の UI を追加しました。
記事・コメント一覧は API 接続前のモックです。

## 関連Issue

Closes #27 

## 変更内容

新規追加ファイル：
```
src/app/articles/[id]/
├── page.tsx
└── styles.module.css
```

- `page.tsx`に記事詳細ページを定義。BlogCard・コメント件数見出し・コメント入力（input / 未接続）・CommentCard 一覧を配置

- ルートの`params`から`id`を取得し、編集リンクは `/articles/${id}/edit` へ遷移（編集ページの実装は不要な範囲）

- 編集リンクは Issue #16（BlogCard）でカード内へ移すまで、ページ側でグリッド重ねの暫定実装（page.tsx 内コメント参照）。

- `styles.module.css` に Figma を参考にしたレイアウトに基づいたスタイルを実装した

- モック・未接続 UI についてはファイル先頭コメントで [BE] 連携後の置き換え前提を記載


## 影響範囲

- [x] UI
- [ ] BE
- [ ] DB/Supabase
- [ ] インフラ/Vercel

## 動作確認方法

1. `npm install` のあと `npm run dev` で起動する
2. ブラウザで `http://localhost:3000/articles/1`（ポートが違う場合はターミナル表示に合わせる）を開く
3. 記事カード・「編集」リンク・コメント件数・入力欄・コメント一覧が表示されることを確認する

## テストケース

- [x] `/articles/1` で記事詳細が表示される
- [x] 「編集」で `/articles/1/edit` に遷移する（編集ページ未実装でも URL のみ可）
- [x] コメント件数と一覧の件数が一致する

## スクリーンショット（UI変更がある場合）

<img width="721" height="628" alt="スクリーンショット 2026-04-22 21 31 44" src="https://github.com/user-attachments/assets/969fd552-91ec-4927-8ed4-62ba1b5bb835" />

## レビューしてほしい部分や不安な部分

- モック・未接続フォームまわりのコメント量・表現
- 編集への `Link` は、過去の `BlogCard` 対応でコンポーネント内から外れてしまったため、本 PR では詳細ページ側に暫定配置しています。Issue #16（BlogCard）でコンポーネント内に戻す対応を予定しています。
- スクロール時に本文（記事詳細のカード周り）がヘッダーより手前に描画され、ヘッダーと重なって見えることがあります。後でレビューで必要と判断された場合は、`Header` コンポーネント側（`z-index` / `position` など）の調整を別対応で行います。
- 画面幅を狭めたとき、`BlogCard`（720px 固定）と `CommentCard` 周りが十分に縮まず、右側が見切れる／はみ出して見えることがあります。必要であれば、ブレークポイントや `max-width`・パディングの見直しなどレスポンシブ対応を別途行います。

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [ ] コンフリクトがあればローカルで解決した（不明なら相談する）

@takanorishinagawa